### PR TITLE
Empty key actions

### DIFF
--- a/inc/spbc-settings.php
+++ b/inc/spbc-settings.php
@@ -4005,6 +4005,12 @@ function spbc_sanitize_settings($settings)
     $settings['spbc_key']      = is_main_site() || $spbc->ms__work_mode != 2 ? $settings['spbc_key'] : $spbc->network_settings['spbc_key'];
     $spbc->data['key_changed'] = $settings['spbc_key'] !== $spbc->settings['spbc_key'];
     $spbc->data['key_is_ok']   = spbc_api_key__is_correct($settings['spbc_key']);
+
+    if ($settings['spbc_key'] === '' && $spbc->data['key_changed']) {
+        $spbc = spbc_drop_to_defaults_on_key_clearance($spbc);
+        \CleantalkSP\SpbctWP\Cron::removeAllTasks();
+    }
+
     $spbc->save('data');
 
     if ($spbc->is_network && $spbc->is_mainsite) {
@@ -5082,4 +5088,34 @@ function spbc__check_if_manual_analysis_results_exist()
     return (bool)$wpdb->get_var(
         "SELECT COUNT(*) FROM " . SPBC_TBL_SCAN_FILES . " WHERE analysis_status IS NOT NULL;"
     );
+}
+
+/**
+ * Drop current data to defaults from state->default_data.
+ * On exceptions roll back to old current state.
+ * Attention! This function does not save the state to options,
+ * only the current state object will be handled.
+ * @param \CleantalkSP\SpbctWP\State $spbc current state
+ * @return \CleantalkSP\SpbctWP\State state dropped
+ */
+function spbc_drop_to_defaults_on_key_clearance(\CleantalkSP\SpbctWP\State $spbc)
+{
+    $old_data = $spbc->data;
+    try {
+        $keep_data_keys = array(
+            'scanner',
+            'display_scanner_warnings',
+            'errors'
+        );
+        $spbc->error_delete_all(true);
+        foreach ( $spbc->default_data as $key => $value) {
+            if (!in_array($key, $keep_data_keys)) {
+                $spbc->data[$key] = $value;
+            }
+        }
+    } catch (Exception $e) {
+        $spbc->data = $old_data;
+    }
+
+    return $spbc;
 }

--- a/lib/CleantalkSP/SpbctWP/Cron.php
+++ b/lib/CleantalkSP/SpbctWP/Cron.php
@@ -173,4 +173,13 @@ class Cron extends \CleantalkSP\Common\Cron
 
         return self::addTask($task, $handler, $period, $first_call, $params);
     }
+
+    /**
+     * Delete all the cron tasks.
+     * @return void
+     */
+    public static function removeAllTasks()
+    {
+        update_option(self::CRON_OPTION_NAME, array());
+    }
 }

--- a/security-malware-firewall.php
+++ b/security-malware-firewall.php
@@ -197,7 +197,12 @@ if ( $spbc->settings && $spbc->key_is_ok) {
         spbc_firewall__check();
     }
 } elseif ( isset($spbc->errors) && ! isset($spbc->errors['apikey']) ) {
-    $spbc->error_add('apikey', __('Unknown access key.', 'security-malware-firewall'));
+    if ($spbc->settings['spbc_key'] === '') {
+        $text = __('Access key is empty.', 'security-malware-firewall');
+    } else {
+        $text = __('Unknown access key.', 'security-malware-firewall');
+    }
+    $spbc->error_add('apikey', $text);
 }
 
 // Disable XMLRPC if setting is enabled


### PR DESCRIPTION
https://doboard.com/1/task/2997

* New. Settings. Drop state data to defaults and remove all the cron tasks on empty key entered. 